### PR TITLE
fix(playbook): fix creation of /etc/mailname and add readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,13 @@
+# Email workshops
+
+It is practical part of lecture made to show how emails works under the hood.
+
+To run it server with ubuntu 20.04 is needed and the rest can be done following instructions in file instructions.md
+
+# Content
+
+* Setting up Postfix, Dovecot and MySql
+* Talking with SMTP server using telnet/openssl
+* Talking with IMAP using curl/telnet/openssl
+* Sending emails using telnet and swaks
+* Setting up DKIM and signing and verifying message message

--- a/ansible/setup_dovecot.yml
+++ b/ansible/setup_dovecot.yml
@@ -6,6 +6,11 @@
     mail_domain: domain
     mail_database: maildb
     mail_db_pass: 'ultrasafepassword'
+  pre_tasks:
+    - name: Create mailname
+      copy:
+        dest: /etc/mailname
+        content: "{{mail_domain}}"
   roles:
     - role: geerlingguy.mysql
       mysql_databases:


### PR DESCRIPTION
/etc/mailname is needed by postfix but it was not created. Add readme.

fix: #3